### PR TITLE
!refactor: remove memstore

### DIFF
--- a/testing/simapp/app.go
+++ b/testing/simapp/app.go
@@ -284,7 +284,7 @@ func NewSimApp(
 		authzkeeper.StoreKey, ibcfeetypes.StoreKey,
 	)
 	tkeys := sdk.NewTransientStoreKeys(paramstypes.TStoreKey)
-	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, multistakingtypes.MemStoreKey)
+	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey)
 
 	app := &SimApp{
 		BaseApp:           bApp,
@@ -359,7 +359,6 @@ func NewSimApp(
 		app.StakingKeeper,
 		app.BankKeeper,
 		keys[multistakingtypes.StoreKey],
-		tkeys[multistakingtypes.MemStoreKey],
 	)
 
 	app.AuthzKeeper = authzkeeper.NewKeeper(keys[authzkeeper.StoreKey], appCodec, app.MsgServiceRouter(), app.AccountKeeper)

--- a/x/multi-staking/keeper/keeper.go
+++ b/x/multi-staking/keeper/keeper.go
@@ -17,7 +17,6 @@ import (
 
 type Keeper struct {
 	storeKey      storetypes.StoreKey
-	memKey        storetypes.StoreKey
 	cdc           codec.BinaryCodec
 	stakingKeeper stakingkeeper.Keeper
 	bankKeeper    types.BankKeeper
@@ -28,12 +27,10 @@ func NewKeeper(
 	stakingKeeper stakingkeeper.Keeper,
 	bankKeeper types.BankKeeper,
 	key storetypes.StoreKey,
-	memKey storetypes.StoreKey,
 ) *Keeper {
 	return &Keeper{
 		cdc:           cdc,
 		storeKey:      key,
-		memKey:        memKey,
 		stakingKeeper: stakingKeeper,
 		bankKeeper:    bankKeeper,
 	}

--- a/x/multi-staking/types/key.go
+++ b/x/multi-staking/types/key.go
@@ -16,9 +16,6 @@ const (
 
 	// QuerierRoute defines the module's query routing key
 	QuerierRoute = ModuleName
-
-	// MemStoreKey defines the in-memory store key
-	MemStoreKey = "memory:capability"
 )
 
 // KVStore keys


### PR DESCRIPTION
- We need to remove memstore as we don't need to use it to get `completed unbonding delegation` anymore.