### PR TITLE
feat: change module account invariant

### DIFF
--- a/x/multi-staking/keeper/abci.go
+++ b/x/multi-staking/keeper/abci.go
@@ -81,6 +81,9 @@ func (k Keeper) BurnUnbondedCoinAndUnlockedMultiStakingCoin(
 	if err != nil {
 		return sdk.Coin{}, err
 	}
+	// burn remaining coin in unlock
+	remaningCoin := unlockEntry.UnlockingCoin.ToCoin().Sub(unlockedCoin)
+	k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(remaningCoin))
 
 	err = k.UnescrowCoinTo(ctx, multiStakerAddr, unlockedCoin)
 	if err != nil {

--- a/x/multi-staking/keeper/invariants.go
+++ b/x/multi-staking/keeper/invariants.go
@@ -42,7 +42,7 @@ func ModuleAccountInvariants(k Keeper) sdk.Invariant {
 		moduleAccount := authtypes.NewModuleAddress(types.ModuleName)
 		escrowBalances := k.bankKeeper.GetAllBalances(ctx, moduleAccount)
 
-		broken := !escrowBalances.IsAllGTE(totalLockCoinAmount)
+		broken := !escrowBalances.IsEqual(totalLockCoinAmount)
 
 		return sdk.FormatInvariant(
 			types.ModuleName,

--- a/x/multi-staking/keeper/invartiants_test.go
+++ b/x/multi-staking/keeper/invartiants_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/realio-tech/multi-staking-module/testutil"
 	"github.com/realio-tech/multi-staking-module/x/multi-staking/keeper"
+	"github.com/realio-tech/multi-staking-module/x/multi-staking/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -117,6 +118,14 @@ func (suite *KeeperTestSuite) TestModuleAccountInvariants() {
 				suite.Require().NoError(err)
 			},
 			expPass: true,
+		},
+		{
+			name: "Fail invariant",
+			malleate: func() {
+				multiStakingLock := types.NewMultiStakingLock(types.MultiStakingLockID(delAddr.String(), valAddr.String()), types.NewMultiStakingCoin(MultiStakingDenomA, sdk.NewInt(200), sdk.OneDec()))
+				suite.app.MultiStakingKeeper.SetMultiStakingLock(suite.ctx, multiStakingLock)
+			},
+			expPass: false,
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
- This PR modify module account invariant to check if module account's balance is equal to total multistaking coins in `Lock\Unlock` entries.
 
- Also we add a logic to burns remaining coin in unlock that's not returned to multistaker.

