### PR TITLE
Improvements: Add defender to avoid MaxEntries condition

### DIFF
--- a/x/multi-staking/keeper/proposal.go
+++ b/x/multi-staking/keeper/proposal.go
@@ -149,6 +149,12 @@ func (k Keeper) RemoveMultiStakingCoinProposal(
 
 	k.RemoveBondWeight(ctx, p.Denom)
 
+	params.MaxEntries -= 1
+	err = k.stakingKeeper.SetParams(ctx, params)
+	if err != nil {
+		return err
+	}
+
 	ctx.EventManager().EmitEvent(
 		sdk.NewEvent(
 			types.EventTypeRemoveMultiStakingCoin,


### PR DESCRIPTION
Scenario: the attackers can continuously create undelegations till reach the max entry to make the proposal fail.
Fix: Forced to increase max entry by 1 to make space in case undelegate entries reach limit