### PR TITLE
Improvement: Handle `zero_shares` dual to slashing/rounding

### DIFF
--- a/x/multi-staking/keeper/invariants.go
+++ b/x/multi-staking/keeper/invariants.go
@@ -41,7 +41,7 @@ func ModuleAccountInvariants(k Keeper) sdk.Invariant {
 
 		moduleAccount := authtypes.NewModuleAddress(types.ModuleName)
 		escrowBalances := k.bankKeeper.GetAllBalances(ctx, moduleAccount)
-		broken := !escrowBalances.Equal(totalLockCoinAmount)
+		broken := !escrowBalances.IsAllGTE(totalLockCoinAmount)
 
 		return sdk.FormatInvariant(
 			types.ModuleName,

--- a/x/multi-staking/keeper/proposal.go
+++ b/x/multi-staking/keeper/proposal.go
@@ -147,7 +147,11 @@ func (k Keeper) RemoveMultiStakingCoinProposal(
 		if unbondAmount.IsZero() {
 			// Remove multistaking-lock and burn corresponding amount
 			k.RemoveMultiStakingLock(ctx, stakingLock.LockID)
-			k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(stakingLock.LockedCoin.ToCoin()))
+			err := k.bankKeeper.BurnCoins(ctx, types.ModuleName, sdk.NewCoins(stakingLock.LockedCoin.ToCoin()))
+			if err != nil {
+				ubdErr = err
+				return true
+			}
 			return false
 		}
 


### PR DESCRIPTION
- Zero shares:
  - Tokens lock but zero shares remain so we could not undelegate theirs delegations => Undelegate fail
  - Delete lock entry and burn corresponding amount to fix this edge case

 